### PR TITLE
Make Brave Dev the default browser, and integrate into SendToOmniFocus

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,8 @@ Install:andUse("URLDispatcher",
                      { "https?://.*webex.com",  "com.google.Chrome" },
                    },
                    -- default_handler = "com.google.Chrome"
-                   default_handler = "com.electron.brave"
+                   -- default_handler = "com.electron.brave"
+                   default_handler = "com.brave.Browser.dev"
                  },
                  start = true
                }
@@ -100,6 +101,7 @@ Install:andUse("SendToOmniFocus",
                    s:registerApplication("Swisscom Collab", { apptype = "chromeapp", itemname = "tab" })
                    s:registerApplication("Swisscom Wiki", { apptype = "chromeapp", itemname = "wiki page" })
                    s:registerApplication("Swisscom Jira", { apptype = "chromeapp", itemname = "issue" })
+                   s:registerApplication("Brave Browser Dev", { apptype = "chromeapp", itemname = "page" })
                  end
                }
 )

--- a/init.org
+++ b/init.org
@@ -110,7 +110,8 @@ The [[http://www.hammerspoon.org/Spoons/URLDispatcher.html][URLDispatcher]] spoo
                        { "https?://.*webex.com",  "com.google.Chrome" },
                      },
                      -- default_handler = "com.google.Chrome"
-                     default_handler = "com.electron.brave"
+                     -- default_handler = "com.electron.brave"
+                     default_handler = "com.brave.Browser.dev"
                    },
                    start = true
                  }
@@ -197,6 +198,7 @@ The [[http://www.hammerspoon.org/Spoons/SendToOmniFocus.html][SendToOmniFocus]] 
                      s:registerApplication("Swisscom Collab", { apptype = "chromeapp", itemname = "tab" })
                      s:registerApplication("Swisscom Wiki", { apptype = "chromeapp", itemname = "wiki page" })
                      s:registerApplication("Swisscom Jira", { apptype = "chromeapp", itemname = "issue" })
+                     s:registerApplication("Brave Browser Dev", { apptype = "chromeapp", itemname = "page" })
                    end
                  }
   )


### PR DESCRIPTION
- Configure URLDispatcher to use Brave Dev
- Add a handler to export the current page from Brave Dev to OmniFocus. As it is based on Chrome, the same handler for any other Chrome-based apps works out of the box.